### PR TITLE
Changing test plan to add type of interface

### DIFF
--- a/commandline.js
+++ b/commandline.js
@@ -8,12 +8,12 @@ this will return the object:
   answerPdfGeneration:  answerPdfGeneration,
   projectName: projectName,
   components: components,
-  browsers: browsers
+  typeOfInterfaceApplication: typeOfInterfaceApplication
 }
 */
 let answer = await testPlanCommandLine()
 
 if(answer.answerPdfGeneration === true){
-    let pdfContent = getPDFContentForServer(answer.projectName, answer.components, answer.browsers)
+    let pdfContent = getPDFContentForServer(answer.projectName, answer.components, answer.typeOfInterfaceApplication)
     pdfModelServer(pdfContent)
 }

--- a/example-pdf-creation-client.js
+++ b/example-pdf-creation-client.js
@@ -1,5 +1,5 @@
 import { pdfModelClient } from './src/pdf/pdf-model-client.js'
 import { getPDFContentForClient } from './src/pdf/models/template.js'
 
-let pdfContent = getPDFContentForClient('My project', 'frontend', 'chrome')
+let pdfContent = getPDFContentForClient('My project', 'frontend', 'web')
 pdfModelClient(pdfContent, 'test-plan')

--- a/example-pdf-creation-server.js
+++ b/example-pdf-creation-server.js
@@ -1,5 +1,5 @@
 import { pdfModelServer } from './src/pdf/pdf-model-server.js'
 import { getPDFContentForServer } from './src/pdf/models/template.js'
 
-let pdfContent = getPDFContentForServer('My project', 'frontend', 'chrome')
+let pdfContent = getPDFContentForServer('My project', 'frontend', 'device')
 pdfModelServer(pdfContent)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "test-artifacts",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "description": "",
   "type": "module",
   "main": "index.js",

--- a/src/command-line/test-plan-commandline.js
+++ b/src/command-line/test-plan-commandline.js
@@ -26,26 +26,26 @@ export async function testPlanCommandLine(){
         ],
     });
 
-    let browsers = 'none';
+    let typeOfInterfaceApplication = 'none';
     if (components != 'backend'){
-         browsers = await select({
-            message: 'Select the browsers you need to test: ',
+        typeOfInterfaceApplication = await select({
+            message: 'Select the type of the interface: ',
             choices: [
             {
-                name: 'chrome',
-                value: 'chrome'
+                name: 'desktop',
+                value: 'desktop'
             },
             {
-                name: 'firefox',
-                value: 'firefox'
+                name: 'web',
+                value: 'web'
             },
             {
-                name: 'safari',
-                value: 'safari',
+                name: 'mobile',
+                value: 'mobile',
             },
             {
-                name: 'chrome + firefox + safari',
-                value: 'chrome + firefox + safari',
+                name: 'desktop + web + mobile',
+                value: 'desktop + web + mobile',
             }
             ],
         });
@@ -57,6 +57,6 @@ export async function testPlanCommandLine(){
         answerPdfGeneration:  answerPdfGeneration,
         projectName: projectName,
         components: components,
-        browsers: browsers
+        typeOfInterfaceApplication: typeOfInterfaceApplication
     }
 }

--- a/src/pdf/models/template.js
+++ b/src/pdf/models/template.js
@@ -1,63 +1,81 @@
-export function getPDFContentForServer(projectName, component, browsers) {
-   
-    let pdfContent = {
-        content: [
-            { 
-                text: `Test Plan for ${projectName}`, 
-                style: 'header' 
-            },
-            { 
-                canvas: [
-                    { type: 'line', x1: 0, y1: 0, x2: 515, y2: 0, lineWidth: 2, lineColor: '#DC143C' }
-                ], 
-                margin: [0, 0, 0, 20]
-            },
-            { 
-                text: 'This Test Plan outlines quality measures in order to delivery the best solution.\n\n', 
-                style: 'subheader'
-            },
-            {
-                text: `Components: ${component}`, 
-                style: 'sectionTitle'
-            },
-            {
-                text: `Browsers: ${browsers}`, 
-                style: 'sectionTitle'
-            },
-            {
-                ul: [
-                    { text: 'Resolution options: iPhone16, iPad, Laptop', style: 'listItem' },
-                    { text: 'Accessibility: WCAG 2.1 compliance', style: 'listItem' },
-                    { text: 'Security: Ensuring user data confidentiality', style: 'listItem' }
-                ],
-                margin: [0, 10, 0, 10]
-            }
-        ],
-        styles: {
-            header: {
-                fontSize: 24,
-                bold: true,
-                color: '#333',
-                margin: [0, 20, 0, 10]
-            },
-            subheader: {
-                fontSize: 16,
-                italics: true,
-                color: '#DC143C',
-                margin: [0, 0, 0, 20]
-            },
-            sectionTitle: {
-                fontSize: 14,
-                bold: true,
-                color: '#DC143C',
-                margin: [0, 15, 0, 5]
-            },
-            listItem: {
-                fontSize: 12,
-                color: '#333',
-                margin: [0, 0, 0, 5]
-            }
+function createCommonPDFContent(projectName, component, typeInterfaceApplication) {
+    return [
+        { 
+            text: `Test Plan for ${projectName}`, 
+            style: 'header' 
         },
+        { 
+            canvas: [
+                { type: 'line', x1: 0, y1: 0, x2: 515, y2: 0, lineWidth: 2, lineColor: '#DC143C' }
+            ], 
+            margin: [0, 0, 0, 20]
+        },
+        { 
+            text: 'This Test Plan outlines quality measures in order to deliver the best solution.\n\n', 
+            style: 'subheader'
+        },
+        {
+            text: `Components: ${component}`, 
+            style: 'sectionTitle'
+        },
+        {
+            text: `Type of Interface Application: ${typeInterfaceApplication}`, 
+            style: 'sectionTitle'
+        },
+        {
+            ul: [
+                { text: 'Resolution options: iPhone16, iPad, Laptop', style: 'listItem' },
+                { text: 'Accessibility: WCAG 2.1 compliance', style: 'listItem' },
+                { text: 'Security: Ensuring user data confidentiality', style: 'listItem' }
+            ],
+            margin: [0, 10, 0, 20]
+        },
+        {text: 'Performance of the application', style: 'header'},
+		'This section is used to match the criterias for performance of this application.',
+		{
+			style: 'tableExample',
+			table: {
+				body: [
+					['What are the key performance metrics for the application?', 'What is the maximum allowable downtime for the application?', 'What are the peak usage times, and how much traffic do you expect during these periods?'],
+					['response time, throughput, resource utilization', 'uptime percentage, maintenance windows', 'daily users, concurrent users, usage spikes']
+				]
+			}
+		}
+    ];
+}
+
+function createPDFStyles() {
+    return {
+        header: {
+            fontSize: 24,
+            bold: true,
+            color: '#333',
+            margin: [0, 20, 0, 10]
+        },
+        subheader: {
+            fontSize: 16,
+            italics: true,
+            color: '#DC143C',
+            margin: [0, 0, 0, 20]
+        },
+        sectionTitle: {
+            fontSize: 14,
+            bold: true,
+            color: '#DC143C',
+            margin: [0, 15, 0, 5]
+        },
+        listItem: {
+            fontSize: 12,
+            color: '#333',
+            margin: [0, 0, 0, 5]
+        }
+    };
+}
+
+export function getPDFContentForServer(projectName, component, browsers) {
+    let pdfContent = {
+        content: createCommonPDFContent(projectName, component, browsers),
+        styles: createPDFStyles(),
         defaultStyle: {
             font: 'Helvetica'
         }
@@ -67,65 +85,9 @@ export function getPDFContentForServer(projectName, component, browsers) {
 }
 
 export function getPDFContentForClient(projectName, component, browsers) {
-   
     let pdfContent = {
-        content: [
-            { 
-                text: `Test Plan for ${projectName}`, 
-                style: 'header' 
-            },
-            { 
-                canvas: [
-                    { type: 'line', x1: 0, y1: 0, x2: 515, y2: 0, lineWidth: 2, lineColor: '#DC143C' }
-                ], 
-                margin: [0, 0, 0, 20]
-            },
-            { 
-                text: 'This Test Plan outlines quality measures in order to delivery the best solution.\n\n', 
-                style: 'subheader'
-            },
-            {
-                text: `Components: ${component}`, 
-                style: 'sectionTitle'
-            },
-            {
-                text: `Browsers: ${browsers}`, 
-                style: 'sectionTitle'
-            },
-            {
-                ul: [
-                    { text: 'Resolution options: iPhone16, iPad, Laptop', style: 'listItem' },
-                    { text: 'Accessibility: WCAG 2.1 compliance', style: 'listItem' },
-                    { text: 'Security: Ensuring user data confidentiality', style: 'listItem' }
-                ],
-                margin: [0, 10, 0, 10]
-            }
-        ],
-        styles: {
-            header: {
-                fontSize: 24,
-                bold: true,
-                color: '#333',
-                margin: [0, 20, 0, 10]
-            },
-            subheader: {
-                fontSize: 16,
-                italics: true,
-                color: '#DC143C',
-                margin: [0, 0, 0, 20]
-            },
-            sectionTitle: {
-                fontSize: 14,
-                bold: true,
-                color: '#DC143C',
-                margin: [0, 15, 0, 5]
-            },
-            listItem: {
-                fontSize: 12,
-                color: '#333',
-                margin: [0, 0, 0, 5]
-            }
-        }
+        content: createCommonPDFContent(projectName, component, browsers),
+        styles: createPDFStyles()
     };
 
     return pdfContent;


### PR DESCRIPTION
Changing test plan to add type of interface:

Now you can use:

let pdfContent = getPDFContentForClient('My project', 'frontend', 'web')
pdfModelClient(pdfContent, 'test-plan')